### PR TITLE
adds .DS_Store to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,8 @@
 .RData
 .Ruserdata
 
+# MacOS .DS_Store file does not provide anything useful to collaborators and
+# causes conflicts between Mac users
+.DS_Store
+
 /.quarto/


### PR DESCRIPTION
.DS_Store is a MacOS specific file that manages certain file explorer (Finder) settings. It provides no useful information to collaborators, but can cause conflicts between MacOS users contributing to the same repo. It should therefore be excluded from Git history.